### PR TITLE
Skip adding favourites to the party in massRemove

### DIFF
--- a/pogo/demo.py
+++ b/pogo/demo.py
@@ -38,6 +38,8 @@ def massRemove(session):
 	
 	# Get the stats for all the pokemon in the party. Easier to store and nicer to display.
 	for pokemon in party:
+		if pokemon.favorite:
+			continue
 		IvPercent = ((pokemon.individual_attack + pokemon.individual_defense + pokemon.individual_stamina)*100)/45
 		L = [pokedex[pokemon.pokemon_id],pokemon.cp,pokemon.individual_attack,pokemon.individual_defense,pokemon.individual_stamina,IvPercent,pokemon]
 		myParty.append(L)


### PR DESCRIPTION
Doesn't mass transfer favorite pokemon over during a mass trade. Solves issue #42.
