### PR TITLE
update demo.py - do not rename or transfer nicknamed pokemon

### DIFF
--- a/pogo/demo.py
+++ b/pogo/demo.py
@@ -64,7 +64,7 @@ def massRemove(session):
 	print ' NAME            | CP    | ATK | DEF | STA | IV% '
 	print '---------------- | ----- | --- | --- | --- | ----'
 	for monster in safeParty:
-		if monster[0] == userPokemon or userPokemon == 'ALL' and monster[0] not in exceptionList:
+		if monster[0] == userPokemon or userPokemon == 'ALL' and monster[0] not in exceptionList and monster[6].nickname == '':
 			if monster[5] > 74:
 				logging.info('\033[1;32;40m %-15s | %-5s | %-3s | %-3s | %-3s | %-3s \033[0m',monster[0],monster[1],monster[2],monster[3],monster[4],monster[5])
 			elif monster[5] > 49:
@@ -241,7 +241,7 @@ def massRename(session):
 	print '---------------- | ----- | --- | --- | --- | ----'
 	refinedParty = []
 	for monster in myParty:
-		if monster[5] > userThreshold and monster[6].nickname != str(monster[5]) + '-' + str(monster[2]) + '/' + str(monster[3]) + '/' + str(monster[4]):
+		if monster[5] > userThreshold and monster[6].nickname == '':
 			logging.info(' %-15s | %-5s | %-3s | %-3s | %-3s | %-3s | %s',monster[0],monster[1],monster[2],monster[3],monster[4],monster[5],monster[6].nickname)
 			refinedParty.append(monster)
 	


### PR DESCRIPTION
there is probably another way to do this, but this would prevent any accidental renames or transfers if the pokemon already has a nickname. to enable transfer, you have to remove their nickname?

possible to implement to transfer duplicate?

for instance I like to cram as much info into my nickname [0-100][1-f][1-f][1-f]-[mv1]/[mv2]
Now, this won't change my custom nicknames, and much easier to manage than favorites.
![image](https://cloud.githubusercontent.com/assets/1276839/17545215/cb2b1590-5e90-11e6-887e-e7087839e46f.png)
